### PR TITLE
don't start docker in detached mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Firefox client to HP ILO server
 # How-to
 
 ### Run this container:
-`docker run -d --rm --name ilo-client -p 5900:5900 -e HILO_HOST=https://ADDRESS_OF_YOUR_HOST -e HILO_USER=SOME_USERNAME -e HILO_PASS=SOME_PASSWORD sshnaidm/docker-ilo-client`
+`docker run --rm --name ilo-client -p 5900:5900 -e HILO_HOST=https://ADDRESS_OF_YOUR_HOST -e HILO_USER=SOME_USERNAME -e HILO_PASS=SOME_PASSWORD sshnaidm/docker-ilo-client`
 
 ### Then run any VNC client and point it to vnc://localhost:5900
 


### PR DESCRIPTION
it wasn't immediately obvious to me how to stop the container after starting it, so either we should document how to stop the container:
`docker stop ilo-client`
 -or- just start docker in the default attached mode (where the container stop on ctrl+C or just exiting the shell)

Another issue is that when people start it in detached mode, not everyone know how to get the docker log.. which is also fixed by not starting it in detached mode.